### PR TITLE
Contract transaction filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,18 @@ eventFilters:
 
 ## Registering a Transaction Monitor
 
-From version 0.5.3, eventeum supports monitoring and broadcasting transactions.  Currently the only matching criteria is by transaction hash, but more will be added in the near future.
+From version 0.6.1, eventeum supports monitoring and broadcasting transactions. The matching criteria can be:
+
+- HASH: Monitor a single transaction hash. The monitoring will be removed once is notified.
+- FROM_ADDRESS: Monitor all transactions that are sent from an specific address.
+- TO_ADDRESS: Monitor all transactions that are received for a specific address.
+
+
+Besides on that, it can monitor the transaction for specific statuses: 
+
+- FAILED: It will notify if the transaction has failed
+- CONFIRMED: It will notify if the transaction is confirmed.
+- UNCONFIRMED: In case the network is configured to wait for a certain number of confirmations, this will notify when is mined and not confirmed.
 
 ### REST
 
@@ -221,7 +232,24 @@ To register a transaction monitor, use the below REST endpoint:
 -   **URL Params:** `N/A`
     - identifier - The transaction hash to monitor
     - nodeName - The node name that should be monitored
--   **Body:** `N/A`
+-   **Body:**
+
+```json
+{
+	"type": "HASH",
+	"transactionIdentifierValue": "0x2e8e0f98be22aa1251584e23f792d43c634744340eb274473e01a48db939f94d",
+	"nodeName": "defaultNetwork",
+	"statuses": ["FAIlED", "CONFIRMATION"]
+}
+```
+
+| Name | Type | Mandatory | Default | Description |
+| -------- | -------- | -------- | -------- | -------- |
+| type | String | yes | | The type of the filter you want to create: `HASH`, `FROM_ADDRESS`, `TO_ADDRESS` |
+| transactionIdentifierValue | String | yes |  | The value associated with the type. It should be the tx hash for `HASH` and the address of the contract in the other cases. |
+| nodeName | String | yes | default | The identifier of the node you want to listen the transaction |
+| statuses | List | no | ['FAILED', 'CONFIRMED'] | It will specify the statuses you want to be notified. The default is failed and confirmed transactions. The options are: `FAILED`, `CONFIRMED`, `UNCONFIRMED`, `INVALIDATED` |
+
 
 -   **Success Response:**
     -   **Code:** 200

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ eventFilters:
 From version 0.6.1, eventeum supports monitoring and broadcasting transactions. The matching criteria can be:
 
 - HASH: Monitor a single transaction hash. The monitoring will be removed once is notified.
-- FROM_ADDRESS: Monitor all transactions that are sent from an specific address.
+- FROM_ADDRESS: Monitor all transactions that are sent from a specific address.
 - TO_ADDRESS: Monitor all transactions that are received for a specific address.
 
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ To register a transaction monitor, use the below REST endpoint:
     - nodeName - The node name that should be monitored
 -   **Body:**
 
+An example with type `HASH`:
+
 ```json
 {
 	"type": "HASH",
@@ -242,6 +244,19 @@ To register a transaction monitor, use the below REST endpoint:
 	"statuses": ["FAIlED", "CONFIRMATION"]
 }
 ```
+
+
+Example filtering by `FROM_ADDRES`, this will notify when a transactions fails with origin the address specified in the field `transactionIdentifierValue`
+
+```json
+{
+	"type": "FROM_ADDRESS" ,
+	"transactionIdentifierValue": "0x1fbBeeE6eC2B7B095fE3c5A572551b1e260Af4d2",
+	"nodeName": "defaultNetwork",
+	"statuses": ["FAIlED"]
+}
+```
+
 
 | Name | Type | Mandatory | Default | Description |
 | -------- | -------- | -------- | -------- | -------- |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ eventFilters:
 
 ## Registering a Transaction Monitor
 
-From version 0.6.1, eventeum supports monitoring and broadcasting transactions. The matching criteria can be:
+From version 0.6.2, eventeum supports monitoring and broadcasting transactions. The matching criteria can be:
 
 - HASH: Monitor a single transaction hash. The monitoring will be removed once is notified.
 - FROM_ADDRESS: Monitor all transactions that are sent from a specific address.

--- a/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
@@ -1,6 +1,7 @@
 package net.consensys.eventeum.chain;
 
 import lombok.AllArgsConstructor;
+import net.consensys.eventeum.chain.config.ContractTransactionFilterConfiguration;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.factory.ContractEventFilterFactory;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
@@ -35,10 +36,12 @@ public class ChainBootstrapper implements InitializingBean {
     private CrudRepository<ContractEventFilter, String> filterRepository;
     private CrudRepository<TransactionMonitoringSpec, String> transactionMonitoringRepository;
     private Optional<List<ContractEventFilterFactory>> contractEventFilterFactories;
+    private ContractTransactionFilterConfiguration transactionFilterConfiguration;
 
     @Override
     public void afterPropertiesSet() throws Exception {
         registerTransactionsToMonitor(transactionMonitoringRepository.findAll(), true);
+        registerTransactionsToMonitor(transactionFilterConfiguration.getConfiguredEventFilters(), true);
 
         subscriptionService.init();
         registerFilters(filterConfiguration.getConfiguredEventFilters(), true);

--- a/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
@@ -39,7 +39,7 @@ public class ChainBootstrapper implements InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         registerTransactionsToMonitor(transactionMonitoringRepository.findAll(), true);
-        registerTransactionsToMonitor(transactionFilterConfiguration.getConfiguredEventFilters(), true);
+        registerTransactionsToMonitor(transactionFilterConfiguration.getConfiguredTransactionFilters(), true);
 
         subscriptionService.init();
         registerFilters(filterConfiguration.getConfiguredEventFilters(), true);

--- a/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/ChainBootstrapper.java
@@ -5,14 +5,12 @@ import net.consensys.eventeum.chain.config.ContractTransactionFilterConfiguratio
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.factory.ContractEventFilterFactory;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
-import net.consensys.eventeum.repository.TransactionMonitoringSpecRepository;
 import net.consensys.eventeum.service.SubscriptionService;
 import net.consensys.eventeum.chain.config.EventFilterConfiguration;
 import net.consensys.eventeum.service.TransactionMonitoringService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Service;
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -188,6 +188,7 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
 
             blockchainService.addBlockListener(new TransactionConfirmationBlockListener(txDetails,
                     blockchainService, broadcaster, confirmationConfig, asyncService,
+                    matchingCriteria.getStatuses(),
                     () -> onConfirmed(txDetails, matchingCriteria)));
 
             broadcastTransaction(txDetails, matchingCriteria);

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -208,7 +208,7 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
     }
 
     private void broadcastTransaction(TransactionDetails txDetails, TransactionMatchingCriteria matchingCriteria) {
-        if (matchingCriteria.getStatuses().contains(txDetails.getStatus().toString())) {
+        if (matchingCriteria.getStatuses().contains(txDetails.getStatus())) {
             broadcaster.broadcastTransaction(txDetails);
         }
     }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -201,7 +201,7 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
 
             broadcastTransaction(txDetails, matchingCriteria);
 
-            if (matchingCriteria.isOneTimeMatch() && matchingCriteria.canBeRemoved()) {
+            if (matchingCriteria.isOneTimeMatch()) {
                 removeMatchingCriteria(matchingCriteria);
             }
         }
@@ -238,7 +238,7 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
     }
 
     private void onConfirmed(TransactionDetails txDetails, TransactionMatchingCriteria matchingCriteria) {
-        if (matchingCriteria.isOneTimeMatch() && matchingCriteria.canBeRemoved()) {
+        if (matchingCriteria.isOneTimeMatch()) {
             log.debug("Tx {} confirmed, removing matchingCriteria", txDetails.getHash());
 
             removeMatchingCriteria(matchingCriteria);

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
@@ -17,11 +17,6 @@ public class FromAddressMatchingCriteria extends SingleValueMatchingCriteria<Str
 
     @Override
     public boolean isOneTimeMatch() {
-        return true;
-    }
-
-    @Override
-    public boolean canBeRemoved() {
         return false;
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
@@ -1,12 +1,13 @@
 package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 
 import java.util.List;
 
 public class FromAddressMatchingCriteria extends SingleValueMatchingCriteria<String> {
 
-    public FromAddressMatchingCriteria(String nodeName, String fromAddress, List<String> statuses) {
+    public FromAddressMatchingCriteria(String nodeName, String fromAddress, List<TransactionStatus> statuses) {
         super(nodeName, fromAddress, statuses);
     }
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/FromAddressMatchingCriteria.java
@@ -1,0 +1,27 @@
+package net.consensys.eventeum.chain.block.tx.criteria;
+
+import net.consensys.eventeum.dto.transaction.TransactionDetails;
+
+import java.util.List;
+
+public class FromAddressMatchingCriteria extends SingleValueMatchingCriteria<String> {
+
+    public FromAddressMatchingCriteria(String nodeName, String fromAddress, List<String> statuses) {
+        super(nodeName, fromAddress, statuses);
+    }
+
+    @Override
+    protected String getValueFromTx(TransactionDetails tx) {
+        return tx.getFrom();
+    }
+
+    @Override
+    public boolean isOneTimeMatch() {
+        return true;
+    }
+
+    @Override
+    public boolean canBeRemoved() {
+        return false;
+    }
+}

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
@@ -14,7 +14,7 @@ public abstract class SingleValueMatchingCriteria<T> implements TransactionMatch
 
     @Override
     public boolean isAMatch(TransactionDetails tx) {
-        return getValueFromTx(tx).equals(valueToMatch);
+        return valueToMatch.equals(getValueFromTx(tx));
     }
 
     protected abstract T getValueFromTx(TransactionDetails tx);

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
@@ -3,6 +3,7 @@ package net.consensys.eventeum.chain.block.tx.criteria;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ public abstract class SingleValueMatchingCriteria<T> implements TransactionMatch
 
     private T valueToMatch;
 
-    private List<String> statuses;
+    private List<TransactionStatus> statuses;
 
     @Override
     public boolean isAMatch(TransactionDetails tx) {

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/SingleValueMatchingCriteria.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public abstract class SingleValueMatchingCriteria<T> implements TransactionMatchingCriteria {
@@ -11,6 +13,8 @@ public abstract class SingleValueMatchingCriteria<T> implements TransactionMatch
     private String nodeName;
 
     private T valueToMatch;
+
+    private List<String> statuses;
 
     @Override
     public boolean isAMatch(TransactionDetails tx) {

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
@@ -1,0 +1,27 @@
+package net.consensys.eventeum.chain.block.tx.criteria;
+
+import net.consensys.eventeum.dto.transaction.TransactionDetails;
+
+import java.util.List;
+
+public class ToAddressMatchingCriteria extends SingleValueMatchingCriteria<String> {
+
+    public ToAddressMatchingCriteria(String nodeName, String toAddress, List<String> statuses) {
+        super(nodeName, toAddress, statuses);
+    }
+
+    @Override
+    protected String getValueFromTx(TransactionDetails tx) {
+        return tx.getTo();
+    }
+
+    @Override
+    public boolean isOneTimeMatch() {
+        return true;
+    }
+
+    @Override
+    public boolean canBeRemoved() {
+        return false;
+    }
+}

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
@@ -1,12 +1,13 @@
 package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 
 import java.util.List;
 
 public class ToAddressMatchingCriteria extends SingleValueMatchingCriteria<String> {
 
-    public ToAddressMatchingCriteria(String nodeName, String toAddress, List<String> statuses) {
+    public ToAddressMatchingCriteria(String nodeName, String toAddress, List<TransactionStatus> statuses) {
         super(nodeName, toAddress, statuses);
     }
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/ToAddressMatchingCriteria.java
@@ -17,11 +17,6 @@ public class ToAddressMatchingCriteria extends SingleValueMatchingCriteria<Strin
 
     @Override
     public boolean isOneTimeMatch() {
-        return true;
-    }
-
-    @Override
-    public boolean canBeRemoved() {
         return false;
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
@@ -2,9 +2,13 @@ package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 
+import java.util.List;
+
 public interface TransactionMatchingCriteria {
 
     String getNodeName();
+
+    List<String> getStatuses();
 
     boolean isAMatch(TransactionDetails tx);
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
@@ -13,6 +13,4 @@ public interface TransactionMatchingCriteria {
     boolean isAMatch(TransactionDetails tx);
 
     boolean isOneTimeMatch();
-
-    boolean canBeRemoved();
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
@@ -13,4 +13,6 @@ public interface TransactionMatchingCriteria {
     boolean isAMatch(TransactionDetails tx);
 
     boolean isOneTimeMatch();
+
+    boolean canBeRemoved();
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TransactionMatchingCriteria.java
@@ -1,6 +1,7 @@
 package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 
 import java.util.List;
 
@@ -8,7 +9,7 @@ public interface TransactionMatchingCriteria {
 
     String getNodeName();
 
-    List<String> getStatuses();
+    List<TransactionStatus> getStatuses();
 
     boolean isAMatch(TransactionDetails tx);
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
@@ -2,10 +2,12 @@ package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 
+import java.util.List;
+
 public class TxHashMatchingCriteria extends SingleValueMatchingCriteria<String> {
 
-    public TxHashMatchingCriteria(String nodeName, String hashToMatch) {
-        super(nodeName, hashToMatch);
+    public TxHashMatchingCriteria(String nodeName, String hashToMatch, List<String> statuses) {
+        super(nodeName, hashToMatch, statuses);
     }
 
     @Override

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
@@ -19,4 +19,9 @@ public class TxHashMatchingCriteria extends SingleValueMatchingCriteria<String> 
     public boolean isOneTimeMatch() {
         return true;
     }
+
+    @Override
+    public boolean canBeRemoved() {
+        return true;
+    }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
@@ -19,9 +19,4 @@ public class TxHashMatchingCriteria extends SingleValueMatchingCriteria<String> 
     public boolean isOneTimeMatch() {
         return true;
     }
-
-    @Override
-    public boolean canBeRemoved() {
-        return true;
-    }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/TxHashMatchingCriteria.java
@@ -1,12 +1,13 @@
 package net.consensys.eventeum.chain.block.tx.criteria;
 
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 
 import java.util.List;
 
 public class TxHashMatchingCriteria extends SingleValueMatchingCriteria<String> {
 
-    public TxHashMatchingCriteria(String nodeName, String hashToMatch, List<String> statuses) {
+    public TxHashMatchingCriteria(String nodeName, String hashToMatch, List<TransactionStatus> statuses) {
         super(nodeName, hashToMatch, statuses);
     }
 

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/factory/DefaultTransactionMatchingCriteriaFactory.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/factory/DefaultTransactionMatchingCriteriaFactory.java
@@ -1,5 +1,7 @@
 package net.consensys.eventeum.chain.block.tx.criteria.factory;
 
+import net.consensys.eventeum.chain.block.tx.criteria.FromAddressMatchingCriteria;
+import net.consensys.eventeum.chain.block.tx.criteria.ToAddressMatchingCriteria;
 import net.consensys.eventeum.chain.block.tx.criteria.TransactionMatchingCriteria;
 import net.consensys.eventeum.chain.block.tx.criteria.TxHashMatchingCriteria;
 import net.consensys.eventeum.model.TransactionIdentifierType;
@@ -12,7 +14,15 @@ public class DefaultTransactionMatchingCriteriaFactory implements TransactionMat
     @Override
     public TransactionMatchingCriteria build(TransactionMonitoringSpec spec) {
         if (spec.getType() == TransactionIdentifierType.HASH) {
-            return new TxHashMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifier());
+            return new TxHashMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifier(), spec.getStatuses());
+        }
+
+        if (spec.getType() == TransactionIdentifierType.TO_ADDRESS) {
+            return new ToAddressMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifierValue(), spec.getStatuses());
+        }
+
+        if (spec.getType() == TransactionIdentifierType.FROM_ADDRESS) {
+            return new FromAddressMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifierValue(), spec.getStatuses());
         }
 
         throw new UnsupportedOperationException("Type: " + spec.getType() + " not currently supported");

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/factory/DefaultTransactionMatchingCriteriaFactory.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/criteria/factory/DefaultTransactionMatchingCriteriaFactory.java
@@ -14,7 +14,7 @@ public class DefaultTransactionMatchingCriteriaFactory implements TransactionMat
     @Override
     public TransactionMatchingCriteria build(TransactionMonitoringSpec spec) {
         if (spec.getType() == TransactionIdentifierType.HASH) {
-            return new TxHashMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifier(), spec.getStatuses());
+            return new TxHashMatchingCriteria(spec.getNodeName(), spec.getTransactionIdentifierValue(), spec.getStatuses());
         }
 
         if (spec.getType() == TransactionIdentifierType.TO_ADDRESS) {

--- a/core/src/main/java/net/consensys/eventeum/chain/config/ContractTransactionFilterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/ContractTransactionFilterConfiguration.java
@@ -1,0 +1,36 @@
+package net.consensys.eventeum.chain.config;
+
+import lombok.Data;
+import net.consensys.eventeum.model.TransactionMonitoringSpec;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties
+@Data
+public class ContractTransactionFilterConfiguration {
+    private List<TransactionMonitoringSpec> contractTransactionFilters;
+
+    public List<TransactionMonitoringSpec> getConfiguredEventFilters() {
+        List<TransactionMonitoringSpec> filtersToReturn = new ArrayList<>();
+
+        if (contractTransactionFilters != null) {
+
+            contractTransactionFilters.forEach((configFilter) -> {
+                final TransactionMonitoringSpec contractTransactionFilter = new TransactionMonitoringSpec(
+                        configFilter.getType(),
+                        configFilter.getTransactionIdentifierValue(),
+                        configFilter.getNodeName(),
+                        configFilter.getStatuses()
+                );
+
+                filtersToReturn.add(contractTransactionFilter);
+            });
+        }
+
+        return filtersToReturn;
+    }
+}

--- a/core/src/main/java/net/consensys/eventeum/chain/config/ContractTransactionFilterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/ContractTransactionFilterConfiguration.java
@@ -14,22 +14,23 @@ import java.util.List;
 public class ContractTransactionFilterConfiguration {
     private List<TransactionMonitoringSpec> contractTransactionFilters;
 
-    public List<TransactionMonitoringSpec> getConfiguredEventFilters() {
+    public List<TransactionMonitoringSpec> getConfiguredTransactionFilters() {
         List<TransactionMonitoringSpec> filtersToReturn = new ArrayList<>();
 
-        if (contractTransactionFilters != null) {
-
-            contractTransactionFilters.forEach((configFilter) -> {
-                final TransactionMonitoringSpec contractTransactionFilter = new TransactionMonitoringSpec(
-                        configFilter.getType(),
-                        configFilter.getTransactionIdentifierValue(),
-                        configFilter.getNodeName(),
-                        configFilter.getStatuses()
-                );
-
-                filtersToReturn.add(contractTransactionFilter);
-            });
+        if (contractTransactionFilters == null) {
+            return filtersToReturn;
         }
+
+        contractTransactionFilters.forEach((configFilter) -> {
+            final TransactionMonitoringSpec contractTransactionFilter = new TransactionMonitoringSpec(
+                    configFilter.getType(),
+                    configFilter.getTransactionIdentifierValue(),
+                    configFilter.getNodeName(),
+                    configFilter.getStatuses()
+            );
+
+            filtersToReturn.add(contractTransactionFilter);
+        });
 
         return filtersToReturn;
     }

--- a/core/src/main/java/net/consensys/eventeum/chain/service/domain/wrapper/Web3jBlock.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/domain/wrapper/Web3jBlock.java
@@ -3,6 +3,7 @@ package net.consensys.eventeum.chain.service.domain.wrapper;
 import lombok.Data;
 import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.chain.service.domain.Transaction;
+import org.web3j.crypto.Keys;
 import org.web3j.protocol.core.methods.response.EthBlock;
 
 import java.util.List;
@@ -40,7 +41,17 @@ public class Web3jBlock implements Block {
 
     private List<Transaction> convertTransactions(List<EthBlock.TransactionResult> toConvert) {
         return toConvert.stream()
-                .map(tx -> new Web3jTransaction((org.web3j.protocol.core.methods.response.Transaction) tx.get()))
+                .map(tx -> {
+                    org.web3j.protocol.core.methods.response.Transaction transaction = (org.web3j.protocol.core.methods.response.Transaction) tx.get();
+
+                    transaction.setFrom(Keys.toChecksumAddress(transaction.getFrom()));
+
+                    if (transaction.getTo() != null && !transaction.getTo().isEmpty()) {
+                        transaction.setTo(Keys.toChecksumAddress(transaction.getTo()));
+                    }
+
+                    return new Web3jTransaction(transaction);
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
@@ -2,9 +2,7 @@ package net.consensys.eventeum.endpoint;
 
 import lombok.AllArgsConstructor;
 import net.consensys.eventeum.constant.Constants;
-import net.consensys.eventeum.dto.transaction.TransactionIdentifier;
 import net.consensys.eventeum.endpoint.response.MonitorTransactionsResponse;
-import net.consensys.eventeum.model.TransactionIdentifierType;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import net.consensys.eventeum.service.exception.NotFoundException;
 import net.consensys.eventeum.service.TransactionMonitoringService;
@@ -27,21 +25,16 @@ public class TransactionMonitoringEndpoint {
     /**
      * Monitors a transaction with the specified hash, on a specific node
      *
-     * @param identifier the transaction identifier (hash for now)
-     * @param nodeName the name of the node that should be monitored for the transaction
+     * @param TransactionMonitoringSpec the transaction spec to add
      * @param response the http response
      */
     @RequestMapping(method = RequestMethod.POST)
-    public MonitorTransactionsResponse monitorTransactions(@RequestParam String identifier,
-                                                           @RequestParam(required = false) String nodeName,
+    public MonitorTransactionsResponse monitorTransactions(@RequestBody TransactionMonitoringSpec spec,
                                                            HttpServletResponse response) {
-
-        if (nodeName == null) {
-            nodeName = Constants.DEFAULT_NODE_NAME;
+        if (spec.getNodeName() == null) {
+            spec.setNodeName(Constants.DEFAULT_NODE_NAME);
         }
 
-        final TransactionMonitoringSpec spec =
-                new TransactionMonitoringSpec(TransactionIdentifierType.HASH, identifier, nodeName);
         monitoringService.registerTransactionsToMonitor(spec);
         response.setStatus(HttpServletResponse.SC_ACCEPTED);
 

--- a/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
@@ -35,6 +35,11 @@ public class TransactionMonitoringEndpoint {
             spec.setNodeName(Constants.DEFAULT_NODE_NAME);
         }
 
+        if (spec.getStatuses() == null || spec.getStatuses().isEmpty()) {
+            spec.setDefaultStatuses();
+        }
+
+        spec.generateId();
         monitoringService.registerTransactionsToMonitor(spec);
         response.setStatus(HttpServletResponse.SC_ACCEPTED);
 

--- a/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
@@ -35,10 +35,6 @@ public class TransactionMonitoringEndpoint {
             spec.setNodeName(Constants.DEFAULT_NODE_NAME);
         }
 
-        if (spec.getStatuses() == null || spec.getStatuses().isEmpty()) {
-            spec.setDefaultStatuses();
-        }
-
         spec.generateId();
         monitoringService.registerTransactionsToMonitor(spec);
         response.setStatus(HttpServletResponse.SC_ACCEPTED);

--- a/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
@@ -31,10 +31,6 @@ public class TransactionMonitoringEndpoint {
     @RequestMapping(method = RequestMethod.POST)
     public MonitorTransactionsResponse monitorTransactions(@RequestBody TransactionMonitoringSpec spec,
                                                            HttpServletResponse response) {
-        if (spec.getNodeName() == null) {
-            spec.setNodeName(Constants.DEFAULT_NODE_NAME);
-        }
-
         spec.generateId();
         monitoringService.registerTransactionsToMonitor(spec);
         response.setStatus(HttpServletResponse.SC_ACCEPTED);

--- a/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/TransactionMonitoringEndpoint.java
@@ -1,7 +1,6 @@
 package net.consensys.eventeum.endpoint;
 
 import lombok.AllArgsConstructor;
-import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.endpoint.response.MonitorTransactionsResponse;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import net.consensys.eventeum.service.exception.NotFoundException;
@@ -32,6 +31,7 @@ public class TransactionMonitoringEndpoint {
     public MonitorTransactionsResponse monitorTransactions(@RequestBody TransactionMonitoringSpec spec,
                                                            HttpServletResponse response) {
         spec.generateId();
+        spec.convertToCheckSum();
         monitoringService.registerTransactionsToMonitor(spec);
         response.setStatus(HttpServletResponse.SC_ACCEPTED);
 

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionIdentifierType.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionIdentifierType.java
@@ -2,5 +2,9 @@ package net.consensys.eventeum.model;
 
 public enum TransactionIdentifierType {
 
-    HASH;
+    HASH,
+
+    TO_ADDRESS,
+
+    FROM_ADDRESS;
 }

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
 import org.web3j.crypto.Hash;
 
@@ -21,7 +22,7 @@ public class TransactionMonitoringSpec {
 
     private TransactionIdentifierType type;
 
-    private String nodeName;
+    private String nodeName = Constants.DEFAULT_NODE_NAME;
 
     private List<TransactionStatus> statuses = Arrays.asList(TransactionStatus.CONFIRMED, TransactionStatus.FAILED);
 

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
@@ -1,9 +1,10 @@
 package net.consensys.eventeum.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.web3j.crypto.Hash;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -17,6 +18,10 @@ public class TransactionMonitoringSpec {
 
     private String nodeName;
 
+    private List<String> statuses;
+
+    private String transactionIdentifierValue;
+
     public TransactionMonitoringSpec(TransactionIdentifierType type,
                                      String transactionIdentifier,
                                      String nodeName) {
@@ -27,4 +32,15 @@ public class TransactionMonitoringSpec {
         this.id = Hash.sha3String(transactionIdentifier + type + nodeName).substring(2);
     }
 
+    public TransactionMonitoringSpec(TransactionIdentifierType type,
+                                     String transactionIdentifierValue,
+                                     String nodeName,
+                                     List<String> statuses) {
+        this.type = type;
+        this.transactionIdentifierValue = transactionIdentifierValue;
+        this.nodeName = nodeName;
+        this.statuses = statuses;
+
+        this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
+    }
 }

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
@@ -23,7 +23,7 @@ public class TransactionMonitoringSpec {
 
     private String nodeName;
 
-    private List<TransactionStatus> statuses;
+    private List<TransactionStatus> statuses = Arrays.asList(TransactionStatus.CONFIRMED, TransactionStatus.FAILED);
 
     private String transactionIdentifierValue;
 
@@ -39,6 +39,17 @@ public class TransactionMonitoringSpec {
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
     }
 
+    public TransactionMonitoringSpec(TransactionIdentifierType type,
+                                     String transactionIdentifierValue,
+                                     String nodeName) {
+        this.type = type;
+        this.transactionIdentifierValue = transactionIdentifierValue;
+        this.nodeName = nodeName;
+
+        this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
+    }
+
+
     @JsonSetter("type")
     public void setType(String type) {
         this.type = TransactionIdentifierType.valueOf(type.toUpperCase());
@@ -51,9 +62,5 @@ public class TransactionMonitoringSpec {
 
     public void generateId() {
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
-    }
-
-    public void setDefaultStatuses() {
-        this.statuses = Arrays.asList(TransactionStatus.CONFIRMED, TransactionStatus.FAILED);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
@@ -1,12 +1,19 @@
 package net.consensys.eventeum.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import net.consensys.eventeum.dto.transaction.TransactionStatus;
 import org.web3j.crypto.Hash;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @NoArgsConstructor
 public class TransactionMonitoringSpec {
 
@@ -14,33 +21,39 @@ public class TransactionMonitoringSpec {
 
     private TransactionIdentifierType type;
 
-    private String transactionIdentifier;
-
     private String nodeName;
 
-    private List<String> statuses;
+    private List<TransactionStatus> statuses;
 
     private String transactionIdentifierValue;
 
     public TransactionMonitoringSpec(TransactionIdentifierType type,
-                                     String transactionIdentifier,
-                                     String nodeName) {
-        this.type = type;
-        this.transactionIdentifier = transactionIdentifier;
-        this.nodeName = nodeName;
-
-        this.id = Hash.sha3String(transactionIdentifier + type + nodeName).substring(2);
-    }
-
-    public TransactionMonitoringSpec(TransactionIdentifierType type,
                                      String transactionIdentifierValue,
                                      String nodeName,
-                                     List<String> statuses) {
+                                     List<TransactionStatus> statuses) {
         this.type = type;
         this.transactionIdentifierValue = transactionIdentifierValue;
         this.nodeName = nodeName;
         this.statuses = statuses;
 
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
+    }
+
+    @JsonSetter("type")
+    public void setType(String type) {
+        this.type = TransactionIdentifierType.valueOf(type.toUpperCase());
+    }
+
+    @JsonSetter("type")
+    public void setType(TransactionIdentifierType type) {
+        this.type = type;
+    }
+
+    public void generateId() {
+        this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
+    }
+
+    public void setDefaultStatuses() {
+        this.statuses = Arrays.asList(TransactionStatus.CONFIRMED, TransactionStatus.FAILED);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
+++ b/core/src/main/java/net/consensys/eventeum/model/TransactionMonitoringSpec.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
 import org.web3j.crypto.Hash;
+import org.web3j.crypto.Keys;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,8 @@ public class TransactionMonitoringSpec {
         this.nodeName = nodeName;
         this.statuses = statuses;
 
+        convertToCheckSum();
+
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
     }
 
@@ -47,9 +50,10 @@ public class TransactionMonitoringSpec {
         this.transactionIdentifierValue = transactionIdentifierValue;
         this.nodeName = nodeName;
 
+        convertToCheckSum();
+
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
     }
-
 
     @JsonSetter("type")
     public void setType(String type) {
@@ -63,5 +67,11 @@ public class TransactionMonitoringSpec {
 
     public void generateId() {
         this.id = Hash.sha3String(transactionIdentifierValue + type + nodeName + statuses.toString()).substring(2);
+    }
+
+    public void convertToCheckSum() {
+        if (this.type != TransactionIdentifierType.HASH) {
+            this.transactionIdentifierValue = Keys.toChecksumAddress(this.transactionIdentifierValue);
+        }
     }
 }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -39,6 +39,17 @@ ethereum:
 #      type: NON_INDEXED_PARAMETER
 #      index: 0
 
+#contractTransactionFilters:
+#- nodeName: ${ETHEREUM_NETWORK:DefaultNetwork}
+#  type: "FROM_ADDRESS"
+#  transactionIdentifierValue: ${CONTRACT_ADDRESS_EM_TOKEN:0x0f8E7A681019Ec13EfE853a6Eca666E05b214Fd5}
+#  statuses: ['CONFIRMED']
+#- nodeName: ${ETHEREUM_NETWORK:DefaultNetwork}
+#  type: "TO_ADDRESS"
+#  transactionIdentifierValue: ${CONTRACT_ADDRESS_EM_TOKEN:0xfBAB8dE62002c86986C6e070BD3bB46BF983C74e}
+#  statuses: ['FAILED']
+
+
 eventStore:
   type: DB
   url: http://localhost:8081/api/rest/v1

--- a/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
@@ -103,7 +103,7 @@ public class ChainBootstrapperTest {
         final List<TransactionMonitoringSpec> mockConfiguredFilters =
                 Arrays.asList(mock(TransactionMonitoringSpec.class), mock(TransactionMonitoringSpec.class));
 
-        when(transactionFilterConfiguration.getConfiguredEventFilters()).thenReturn(mockConfiguredFilters);
+        when(transactionFilterConfiguration.getConfiguredTransactionFilters()).thenReturn(mockConfiguredFilters);
 
         doBootstrap();
 

--- a/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
@@ -97,6 +97,20 @@ public class ChainBootstrapperTest {
         verify(mockTransactionMonitoringService, times(1)).registerTransactionsToMonitor(mockMonitorSpecs.get(1), true);
     }
 
+    @Test
+    public void testThatContractTransactionFiltersAreRegistered() throws Exception {
+
+        final List<TransactionMonitoringSpec> mockConfiguredFilters =
+                Arrays.asList(mock(TransactionMonitoringSpec.class), mock(TransactionMonitoringSpec.class));
+
+        when(transactionFilterConfiguration.getConfiguredEventFilters()).thenReturn(mockConfiguredFilters);
+
+        doBootstrap();
+
+        verify(mockTransactionMonitoringService, times(1)).registerTransactionsToMonitor(mockConfiguredFilters.get(0), true);
+        verify(mockTransactionMonitoringService, times(1)).registerTransactionsToMonitor(mockConfiguredFilters.get(1), true);
+     }
+
     private void doBootstrap() throws Exception {
         underTest.afterPropertiesSet();
     }

--- a/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/ChainBootstrapperTest.java
@@ -1,5 +1,6 @@
 package net.consensys.eventeum.chain;
 
+import net.consensys.eventeum.chain.config.ContractTransactionFilterConfiguration;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.factory.ContractEventFilterFactory;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
@@ -47,6 +48,10 @@ public class ChainBootstrapperTest {
     @Mock
     private ContractEventFilterFactory mockFilterFactory;
 
+    @Mock
+    private ContractTransactionFilterConfiguration transactionFilterConfiguration;
+
+
     private List<BlockListener> mockBlockListeners =
             Arrays.asList(mock(BlockListener.class), mock(BlockListener.class));
 
@@ -56,7 +61,7 @@ public class ChainBootstrapperTest {
     public void init() {
         underTest = new ChainBootstrapper(mockSubscriptionService, mockTransactionMonitoringService, mockConfig,
                 mockFilterRepository, mockTransactionMonitoringRepository,
-                Optional.of(Collections.singletonList(mockFilterFactory)));
+                Optional.of(Collections.singletonList(mockFilterFactory)), transactionFilterConfiguration);
     }
 
     @Test

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,6 +39,16 @@ ethereum:
 #      type: NON_INDEXED_PARAMETER
 #      index: 0
 
+#contractTransactionFilters:
+#- nodeName: ${ETHEREUM_NETWORK:DefaultNetwork}
+#  type: "FROM_ADDRESS"
+#  transactionIdentifierValue: ${CONTRACT_ADDRESS_EM_TOKEN:0x0f8E7A681019Ec13EfE853a6Eca666E05b214Fd5}
+#  statuses: ['CONFIRMED']
+#- nodeName: ${ETHEREUM_NETWORK:DefaultNetwork}
+#  type: "TO_ADDRESS"
+#  transactionIdentifierValue: ${CONTRACT_ADDRESS_EM_TOKEN:0xfBAB8dE62002c86986C6e070BD3bB46BF983C74e}
+#  statuses: ['FAILED']
+
 eventStore:
   type: DB
   url: http://localhost:8081/api/rest/v1

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
@@ -18,6 +18,7 @@ import net.consensys.eventeum.dto.transaction.TransactionIdentifier;
 import net.consensys.eventeum.endpoint.response.AddEventFilterResponse;
 import net.consensys.eventeum.endpoint.response.MonitorTransactionsResponse;
 import net.consensys.eventeum.integration.eventstore.db.repository.ContractEventDetailsRepository;
+import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import net.consensys.eventeum.repository.ContractEventFilterRepository;
 import net.consensys.eventeum.utils.JSON;
 import net.consensys.eventeumserver.integrationtest.utils.SpringRestarter;
@@ -215,9 +216,9 @@ public class BaseIntegrationTest {
         return filter;
     }
 
-    protected String monitorTransaction(String txHash) {
+    protected String monitorTransaction(TransactionMonitoringSpec monitorSpec) {
         final ResponseEntity<MonitorTransactionsResponse> response =
-                restTemplate.postForEntity(restUrl + "/api/rest/v1/transaction?identifier=" + txHash, "", MonitorTransactionsResponse.class);
+                restTemplate.postForEntity(restUrl + "/api/rest/v1/transaction", monitorSpec, MonitorTransactionsResponse.class);
 
         registeredTransactionMonitorIds.add(response.getBody().getId());
         return response.getBody().getId();

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterDBEventStoreIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterDBEventStoreIT.java
@@ -70,8 +70,18 @@ public class BroadcasterDBEventStoreIT extends MainBroadcasterTests {
     }
 
     @Test
-    public void testBroadcastFailedTransaction() throws Exception {
-        doTestBroadcastFailedTransaction();
+    public void testBroadcastFailedTransactionFilteredByHash() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByHash();
+    }
+
+    @Test
+    public void testBroadcastFailedTransactionFilteredByTo() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByTo();
+    }
+
+    @Test
+    public void testBroadcastFailedTransactionFilteredByFrom() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByFrom();
     }
 
     @Test

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterSmokeTest.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterSmokeTest.java
@@ -1,11 +1,14 @@
 package net.consensys.eventeumserver.integrationtest;
 
+import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.dto.event.ContractEventDetails;
 import net.consensys.eventeum.dto.event.ContractEventStatus;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
+import net.consensys.eventeum.model.TransactionIdentifierType;
+import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -48,7 +51,9 @@ public abstract class BroadcasterSmokeTest extends BaseIntegrationTest {
     public void testBroadcastTransactionEvent() throws Exception {
 
         final String txHash = sendTransaction();
-        monitorTransaction(txHash);
+        TransactionMonitoringSpec monitorSpec = new TransactionMonitoringSpec(TransactionIdentifierType.HASH, txHash, Constants.DEFAULT_NODE_NAME);
+
+        monitorTransaction(monitorSpec);
 
         waitForTransactionMessages(1);
 

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/EventeumEventConsumingIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/EventeumEventConsumingIT.java
@@ -75,7 +75,7 @@ public class EventeumEventConsumingIT extends BaseKafkaIntegrationTest {
 
         final TransactionMonitoringSpec spec = new TransactionMonitoringSpec();
         spec.setNodeName("default");
-        spec.setTransactionIdentifier(txHash);
+        spec.setTransactionIdentifierValue(txHash);
         spec.setType(TransactionIdentifierType.HASH);
 
         broadcaster.broadcastTransactionMonitorAdded(spec);
@@ -101,7 +101,7 @@ public class EventeumEventConsumingIT extends BaseKafkaIntegrationTest {
 
         final TransactionMonitoringSpec spec = new TransactionMonitoringSpec();
         spec.setNodeName("default");
-        spec.setTransactionIdentifier(txHash);
+        spec.setTransactionIdentifierValue(txHash);
         spec.setType(TransactionIdentifierType.HASH);
 
         broadcaster.broadcastTransactionMonitorAdded(spec);

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/MainBroadcasterTests.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/MainBroadcasterTests.java
@@ -1,29 +1,20 @@
 package net.consensys.eventeumserver.integrationtest;
 
+import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.dto.event.ContractEventDetails;
 import net.consensys.eventeum.dto.event.ContractEventStatus;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
-import net.consensys.eventeum.dto.message.ContractEventFilterAdded;
-import net.consensys.eventeum.dto.message.ContractEventFilterRemoved;
-import net.consensys.eventeum.dto.message.EventeumMessage;
-import net.consensys.eventeum.dto.message.TransactionMonitorAdded;
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
+import net.consensys.eventeum.model.TransactionIdentifierType;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
-import net.consensys.eventeum.utils.JSON;
 import org.junit.Assert;
-import org.junit.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
 import org.web3j.crypto.Hash;
 
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
 
 public abstract class MainBroadcasterTests extends BaseKafkaIntegrationTest {
@@ -135,8 +126,9 @@ public abstract class MainBroadcasterTests extends BaseKafkaIntegrationTest {
     private String monitorSendAndAssertTransactionBroadcast(
             String signedTxHex, TransactionStatus expectedStatus) throws ExecutionException, InterruptedException {
 
-        final String txHash = Hash.sha3(signedTxHex);
-        monitorTransaction(txHash);
+        final String txHash = Hash.sha3(signedTxHex);TransactionMonitoringSpec monitorSpec = new TransactionMonitoringSpec(TransactionIdentifierType.HASH, txHash, Constants.DEFAULT_NODE_NAME);
+
+        monitorTransaction(monitorSpec);
 
         assertEquals(txHash, sendRawTransaction(signedTxHex));
 

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
@@ -119,7 +119,7 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
         final Optional<TransactionMonitoringSpec> saved =
                 transactionMonitoringSpecRepository.findById(monitorId);
         assertEquals(monitorId, saved.get().getId());
-        assertEquals(txHash, saved.get().getTransactionIdentifier());
+        assertEquals(txHash, saved.get().getTransactionIdentifierValue());
 
         return monitorId;
     }
@@ -136,7 +136,7 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
                 getBroadcastTransactionEventMessages().get(0);
 
         assertEquals(true, broadcastMessage instanceof TransactionMonitorAdded);
-        assertEquals(txHash, broadcastMessage.getDetails().getTransactionIdentifier());
+        assertEquals(txHash, broadcastMessage.getDetails().getTransactionIdentifierValue());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
 
         assertEquals(true, broadcastMessage instanceof TransactionMonitorRemoved);
         assertEquals(monitorId, broadcastMessage.getDetails().getId());
-        assertEquals(txHash, broadcastMessage.getDetails().getTransactionIdentifier());
+        assertEquals(txHash, broadcastMessage.getDetails().getTransactionIdentifierValue());
     }
 
     private String generateTxHash() {

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
@@ -1,7 +1,9 @@
 package net.consensys.eventeumserver.integrationtest;
 
+import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.message.*;
+import net.consensys.eventeum.model.TransactionIdentifierType;
 import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import net.consensys.eventeum.repository.TransactionMonitoringSpecRepository;
 import org.junit.Test;
@@ -113,7 +115,9 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
     }
 
     private String doTestRegisterTransactionMonitorSavesInDb(String txHash) {
-        final String monitorId = monitorTransaction(txHash);
+        TransactionMonitoringSpec monitorSpec = new TransactionMonitoringSpec(TransactionIdentifierType.HASH, txHash, Constants.DEFAULT_NODE_NAME);
+
+        final String monitorId = monitorTransaction(monitorSpec);
 
         transactionMonitoringSpecRepository.findAll();
         final Optional<TransactionMonitoringSpec> saved =
@@ -128,7 +132,9 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
     public void testRegisterTransactionMonitorBroadcastsAddedMessage() throws InterruptedException {
         final String txHash = generateTxHash();
 
-        monitorTransaction(txHash);
+        TransactionMonitoringSpec monitorSpec = new TransactionMonitoringSpec(TransactionIdentifierType.HASH, txHash, Constants.DEFAULT_NODE_NAME);
+
+        monitorTransaction(monitorSpec);
         waitForBroadcast();
         assertEquals(1, getBroadcastTransactionEventMessages().size());
 

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/ServiceRestartRecoveryTests.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/ServiceRestartRecoveryTests.java
@@ -1,47 +1,30 @@
 package net.consensys.eventeumserver.integrationtest;
 
 import junit.framework.TestCase;
-import net.consensys.eventeum.annotation.EnableEventeum;
+import net.consensys.eventeum.constant.Constants;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.dto.event.ContractEventDetails;
 import net.consensys.eventeum.dto.event.ContractEventStatus;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.transaction.TransactionDetails;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
-import net.consensys.eventeum.integration.eventstore.db.repository.LatestBlockRepository;
-import net.consensys.eventeum.model.LatestBlock;
+import net.consensys.eventeum.model.TransactionIdentifierType;
+import net.consensys.eventeum.model.TransactionMonitoringSpec;
 import net.consensys.eventeum.repository.TransactionMonitoringSpecRepository;
-import net.consensys.eventeumserver.Application;
-import net.consensys.eventeumserver.integrationtest.utils.ExcludeEmbeddedMongoApplication;
 import net.consensys.eventeumserver.integrationtest.utils.RestartingSpringRunner;
-import net.consensys.eventeumserver.integrationtest.utils.SpringRestarter;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.CacheAwareContextLoaderDelegate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.web3j.crypto.Hash;
-import org.web3j.protocol.Web3j;
-import org.web3j.protocol.http.HttpService;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -151,7 +134,9 @@ public abstract class ServiceRestartRecoveryTests extends BaseKafkaIntegrationTe
 
         final String txHash = Hash.sha3(signedHex);
 
-        monitorTransaction(txHash);
+        TransactionMonitoringSpec monitorSpec = new TransactionMonitoringSpec(TransactionIdentifierType.HASH, txHash, Constants.DEFAULT_NODE_NAME);
+
+        monitorTransaction(monitorSpec);
 
         txRepo.findAll();
 


### PR DESCRIPTION
- Adds the possibility to filter transactions by status and by type.
- Adds the possibility to configure the filters by configuration yml or by Api rest.
- The api rest has been changed from getting the params in the url to getting them from the body.
- In the `convertTransactions` hander the `from` and the `to` has been checksummed. The reason behind that is that all the comparisons to check if the address match with the transaction to filter has to be done in a standard way.
- The readme has been updated with the proper info.