### PR TITLE
Restore start block on event filter endpoint

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/endpoint/ContractEventFilterEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/ContractEventFilterEndpoint.java
@@ -18,7 +18,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
-import net.consensys.eventeum.endpoint.exception.BadRequestException;
 import net.consensys.eventeum.endpoint.response.AddEventFilterResponse;
 import net.consensys.eventeum.service.SubscriptionService;
 import net.consensys.eventeum.service.exception.NotFoundException;
@@ -45,11 +44,6 @@ public class ContractEventFilterEndpoint {
   @RequestMapping(method = RequestMethod.POST)
   public AddEventFilterResponse addEventFilter(
       @RequestBody ContractEventFilter eventFilter, HttpServletResponse response) {
-
-    if (eventFilter.getStartBlock() != null) {
-      throw new BadRequestException(
-          "Filters registered via REST do not support the startBlock attribute");
-    }
 
     final ContractEventFilter registeredFilter =
         filterService.registerContractEventFilter(eventFilter, true);


### PR DESCRIPTION
The possibility to pass the initial block in the filters, a feature that exists and should be present, has been lost