### PR TITLE
Remove privacy plugin from server because can't start with it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </modules>
 
     <properties>
-        <revision>2.0.1</revision>
+        <revision>2.0.2</revision>
         <java.version>21</java.version>
         <web3j.version>4.12.0</web3j.version>
         <springcloud.version>4.1.2</springcloud.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -64,11 +64,6 @@
             <artifactId>eventeum-core</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>io.eventeum</groupId>
-            <artifactId>eventeum-privacy-plugin</artifactId>
-            <version>${revision}</version>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>


### PR DESCRIPTION
Remove privacy plugin from server because eventeum can't start with

`java.util.concurrent.CompletionException: java.lang.ClassCastException: class net.consensys.eventeum.chain.service.Web3jService cannot be cast to class net.consensys.eventeum.plugin.chain.service.Web3JEeaService`

I think there are some dependencies that try to mix versions and not working
