### PR TITLE
fix: Serialize ContractEvent NumberParameter value as String to avoid E notation

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/config/JacksonAutoConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/JacksonAutoConfiguration.java
@@ -15,7 +15,10 @@
 package net.consensys.eventeum.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import net.consensys.eventeum.dto.event.parameter.NumberParameter;
+import net.consensys.eventeum.dto.event.serializer.NumberParameterSerializer;
 import net.consensys.eventeum.integration.mixin.PageMixIn;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -38,6 +41,11 @@ public class JacksonAutoConfiguration {
     ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(new JavaTimeModule());
     mapper.addMixIn(Page.class, PageMixIn.class);
+
+
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(NumberParameter.class, new NumberParameterSerializer());
+    mapper.registerModule(module);
 
     return mapper;
   }

--- a/core/src/main/java/net/consensys/eventeum/dto/event/parameter/NumberParameter.java
+++ b/core/src/main/java/net/consensys/eventeum/dto/event/parameter/NumberParameter.java
@@ -14,11 +14,13 @@
 
 package net.consensys.eventeum.dto.event.parameter;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jakarta.persistence.Embeddable;
 import java.math.BigInteger;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import net.consensys.eventeum.dto.event.serializer.NumberParameterSerializer;
 
 /**
  * A number based EventParameter, represented by a BigInteger.
@@ -29,6 +31,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@JsonSerialize(using = NumberParameterSerializer.class)
 public class NumberParameter extends AbstractEventParameter<BigInteger> {
 
   public NumberParameter(String type, BigInteger value) {

--- a/core/src/main/java/net/consensys/eventeum/dto/event/serializer/NumberParameterSerializer.java
+++ b/core/src/main/java/net/consensys/eventeum/dto/event/serializer/NumberParameterSerializer.java
@@ -1,0 +1,33 @@
+package net.consensys.eventeum.dto.event.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import net.consensys.eventeum.dto.event.parameter.NumberParameter;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+
+@JsonComponent
+public class NumberParameterSerializer
+        extends JsonSerializer<NumberParameter> {
+    @Override
+    public void serialize(NumberParameter value,
+                          JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStringField("type", value.getType());
+        jsonGenerator.writeStringField("value", value.getValueString());
+    }
+
+    @Override
+    public void serializeWithType(NumberParameter value, JsonGenerator gen,
+                                  SerializerProvider provider, TypeSerializer typeSer)
+            throws IOException {
+
+        typeSer.writeTypePrefixForObject(value, gen);
+        serialize(value, gen, provider); // call your customized serialize method
+        typeSer.writeTypeSuffixForObject(value, gen);
+    }
+}

--- a/core/src/main/java/net/consensys/eventeum/dto/event/serializer/NumberParameterSerializer.java
+++ b/core/src/main/java/net/consensys/eventeum/dto/event/serializer/NumberParameterSerializer.java
@@ -27,7 +27,7 @@ public class NumberParameterSerializer
             throws IOException {
 
         typeSer.writeTypePrefixForObject(value, gen);
-        serialize(value, gen, provider); // call your customized serialize method
+        serialize(value, gen, provider);
         typeSer.writeTypeSuffixForObject(value, gen);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/utils/JSON.java
+++ b/core/src/main/java/net/consensys/eventeum/utils/JSON.java
@@ -16,6 +16,9 @@ package net.consensys.eventeum.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import net.consensys.eventeum.dto.event.parameter.NumberParameter;
+import net.consensys.eventeum.dto.event.serializer.NumberParameterSerializer;
 
 /**
  * Useful JSON based utility methods.
@@ -27,6 +30,10 @@ public class JSON {
 
   public static String stringify(Object object) {
     try {
+      SimpleModule module = new SimpleModule();
+      module.addSerializer(NumberParameter.class, new NumberParameterSerializer());
+      objectMapper.registerModule(module);
+
       return objectMapper.writeValueAsString(object);
     } catch (JsonProcessingException e) {
       e.printStackTrace();

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </modules>
 
     <properties>
-        <revision>2.0.2</revision>
+        <revision>2.0.3</revision>
         <java.version>21</java.version>
         <web3j.version>4.12.0</web3j.version>
         <springcloud.version>4.1.2</springcloud.version>


### PR DESCRIPTION
Published event before the change (pay attention to non-indexed parameters):
```
{
    "id": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145-0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983-104",
    "type": "CONTRACT_EVENT",
    "details": {
        "name": "Transfer",
        "filterId": "Transfer.omi",
        "nodeName": "Base",
        "indexedParameters": [
            {
                "type": "address",
                "value": "0x802b65b5d9016621E66003aeD0b16615093f328b"
            },
            {
                "type": "address",
                "value": "0x6E7b4416E3a2b873F6Cd4840e6bee7d88f07dA8f"
            }
        ],
        "nonIndexedParameters": [
            {
                "type": "uint256",
                "value": 1.8879407884506388e+22 <-----  HERE
            }
        ],
        "transactionHash": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145",
        "logIndex": 104,
        "blockNumber": 25599977,
        "blockHash": "0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983",
        "address": "0x3792DBDD07e87413247DF995e692806aa13D3299",
        "from": "0xa1fcbad69fb552327b7bde3faba25394cf336b30",
        "status": "CONFIRMED",
        "eventSpecificationSignature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
        "networkName": "Base",
        "timestamp": 1737989301,
        "blockTimestamp": 1737989301,
        "id": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145-0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983-104"
    },
    "retries": 0
}
```
Published Event after custom serializer is added:
```
{
    "id": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145-0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983-104",
    "type": "CONTRACT_EVENT",
    "details": {
        "name": "Transfer",
        "filterId": "Transfer.omi",
        "nodeName": "Base",
        "indexedParameters": [
            {
                "type": "address",
                "value": "0x802b65b5d9016621E66003aeD0b16615093f328b"
            },
            {
                "type": "address",
                "value": "0x6E7b4416E3a2b873F6Cd4840e6bee7d88f07dA8f"
            }
        ],
        "nonIndexedParameters": [
            {
                "type": "uint256",
                "value": "18879407884506387414003"  <-----  HERE
            }
        ],
        "transactionHash": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145",
        "logIndex": 104,
        "blockNumber": 25599977,
        "blockHash": "0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983",
        "address": "0x3792DBDD07e87413247DF995e692806aa13D3299",
        "from": "0xa1fcbad69fb552327b7bde3faba25394cf336b30",
        "status": "CONFIRMED",
        "eventSpecificationSignature": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
        "networkName": "Base",
        "timestamp": 1737989301,
        "blockTimestamp": 1737989301,
        "id": "0xb184f561c925ee44b932cfd6c2e55e221042805b5d44f5c15f4e956c357ee145-0x5724cdcd173415df17171208bdbc11dc7b217da04160b8d3208665f2313d6983-104"
    },
    "retries": 0
}
```